### PR TITLE
Replace missing stsci-hst package in HSTDP 2018.1 OSX spec files

### DIFF
--- a/hstdp/2018.1/dev/hstdp-2018.1-osx-py35.01.txt
+++ b/hstdp/2018.1/dev/hstdp-2018.1-osx-py35.01.txt
@@ -104,7 +104,7 @@ https://repo.continuum.io/pkgs/main/osx-64/sphinxcontrib-1.0-py35h3eabf46_1.tar.
 https://repo.continuum.io/pkgs/main/osx-64/sphinxcontrib-websupport-1.0.1-py35hcb4ca16_1.tar.bz2
 https://repo.continuum.io/pkgs/main/osx-64/sqlite-3.22.0-h3efe00b_0.tar.bz2
 http://ssb.stsci.edu/astroconda/osx-64/stistools-1.1-py35_1.tar.bz2
-http://ssb.stsci.edu/astroconda/osx-64/stsci-hst-3.0.1-0.tar.bz2
+http://ssb.stsci.edu/astroconda/osx-64/stsci-hst-3.0.2-py35_0.tar.bz2
 http://ssb.stsci.edu/astroconda/osx-64/stsci.convolve-2.2.1-py35_0.tar.bz2
 http://ssb.stsci.edu/astroconda/osx-64/stsci.distutils-0.3.8-py35_1.tar.bz2
 http://ssb.stsci.edu/astroconda/osx-64/stsci.image-2.2.0-py35_1.tar.bz2

--- a/hstdp/2018.1/dev/hstdp-2018.1-osx-py36.01.txt
+++ b/hstdp/2018.1/dev/hstdp-2018.1-osx-py36.01.txt
@@ -104,7 +104,7 @@ https://repo.continuum.io/pkgs/main/osx-64/sphinxcontrib-1.0-py36h9364dc8_1.tar.
 https://repo.continuum.io/pkgs/main/osx-64/sphinxcontrib-websupport-1.0.1-py36h92f4a7a_1.tar.bz2
 https://repo.continuum.io/pkgs/main/osx-64/sqlite-3.22.0-h3efe00b_0.tar.bz2
 http://ssb.stsci.edu/astroconda/osx-64/stistools-1.1-py36_1.tar.bz2
-http://ssb.stsci.edu/astroconda/osx-64/stsci-hst-3.0.1-0.tar.bz2
+http://ssb.stsci.edu/astroconda/osx-64/stsci-hst-3.0.2-py36_0.tar.bz2
 http://ssb.stsci.edu/astroconda/osx-64/stsci.convolve-2.2.1-py36_0.tar.bz2
 http://ssb.stsci.edu/astroconda/osx-64/stsci.distutils-0.3.8-py36_1.tar.bz2
 http://ssb.stsci.edu/astroconda/osx-64/stsci.image-2.2.0-py36_1.tar.bz2

--- a/hstdp/2018.1/hstdp-2018.1-osx-py35.final.txt
+++ b/hstdp/2018.1/hstdp-2018.1-osx-py35.final.txt
@@ -104,7 +104,7 @@ https://repo.continuum.io/pkgs/main/osx-64/sphinxcontrib-1.0-py35h3eabf46_1.tar.
 https://repo.continuum.io/pkgs/main/osx-64/sphinxcontrib-websupport-1.0.1-py35hcb4ca16_1.tar.bz2
 https://repo.continuum.io/pkgs/main/osx-64/sqlite-3.22.0-h3efe00b_0.tar.bz2
 http://ssb.stsci.edu/astroconda/osx-64/stistools-1.1-py35_1.tar.bz2
-http://ssb.stsci.edu/astroconda/osx-64/stsci-hst-3.0.1-0.tar.bz2
+http://ssb.stsci.edu/astroconda/osx-64/stsci-hst-3.0.2-py35_0.tar.bz2
 http://ssb.stsci.edu/astroconda/osx-64/stsci.convolve-2.2.1-py35_0.tar.bz2
 http://ssb.stsci.edu/astroconda/osx-64/stsci.distutils-0.3.8-py35_1.tar.bz2
 http://ssb.stsci.edu/astroconda/osx-64/stsci.image-2.2.0-py35_1.tar.bz2

--- a/hstdp/2018.1/hstdp-2018.1-osx-py36.final.txt
+++ b/hstdp/2018.1/hstdp-2018.1-osx-py36.final.txt
@@ -104,7 +104,7 @@ https://repo.continuum.io/pkgs/main/osx-64/sphinxcontrib-1.0-py36h9364dc8_1.tar.
 https://repo.continuum.io/pkgs/main/osx-64/sphinxcontrib-websupport-1.0.1-py36h92f4a7a_1.tar.bz2
 https://repo.continuum.io/pkgs/main/osx-64/sqlite-3.22.0-h3efe00b_0.tar.bz2
 http://ssb.stsci.edu/astroconda/osx-64/stistools-1.1-py36_1.tar.bz2
-http://ssb.stsci.edu/astroconda/osx-64/stsci-hst-3.0.1-0.tar.bz2
+http://ssb.stsci.edu/astroconda/osx-64/stsci-hst-3.0.2-py36_0.tar.bz2
 http://ssb.stsci.edu/astroconda/osx-64/stsci.convolve-2.2.1-py36_0.tar.bz2
 http://ssb.stsci.edu/astroconda/osx-64/stsci.distutils-0.3.8-py36_1.tar.bz2
 http://ssb.stsci.edu/astroconda/osx-64/stsci.image-2.2.0-py36_1.tar.bz2


### PR DESCRIPTION
Replace problematic (removed) stsci-hst-3.0.1 package with stsci-hst-3.0.2.

stsci-hst-3.0.1 had no python version associated with it due to conda-build issues and would cause significant problems in solving a conda environment. It had to be removed from the channel. This PR replaces it retroactively.