### PR TITLE
Correct erroneous local paths, remove staging channel, and standardize YAML files

### DIFF
--- a/hstdp/2019.3/dev/hstdp-2019.3-linux-py36.00.yml
+++ b/hstdp/2019.3/dev/hstdp-2019.3-linux-py36.00.yml
@@ -1,4 +1,3 @@
-name: hstdp-2019.3-linux-py36.00
 channels:
   - http://ssb.stsci.edu/astroconda
   - defaults
@@ -164,4 +163,3 @@ dependencies:
   - tweakwcs=0.5.0=py36_0
   - pip:
     - dask==0.19.4
-prefix: /srv/jenkins/workspace/Sandbox/delivery_merge/miniconda3/envs/hstdp-2019.3-linux-py36.00

--- a/hstdp/2019.3/dev/hstdp-2019.3-linux-py36.01.yml
+++ b/hstdp/2019.3/dev/hstdp-2019.3-linux-py36.01.yml
@@ -1,4 +1,3 @@
-name: hstdp-2019.3-linux-py36.01
 channels:
   - http://ssb.stsci.edu/astroconda
   - defaults
@@ -164,4 +163,3 @@ dependencies:
   - tweakwcs=0.5.0=py36_0
   - pip:
     - dask==0.19.4
-prefix: /srv/jenkins/workspace/Sandbox/delivery_merge/miniconda3/envs/hstdp-2019.3-linux-py36.01

--- a/hstdp/2019.3/dev/hstdp-2019.3-linux-py36.02.yml
+++ b/hstdp/2019.3/dev/hstdp-2019.3-linux-py36.02.yml
@@ -1,4 +1,3 @@
-name: hstdp-2019.3-linux-py36.02
 channels:
   - http://ssb.stsci.edu/astroconda
   - defaults
@@ -164,4 +163,3 @@ dependencies:
   - photutils=0.6.dev121+gcc9bb45=py36_0
   - pip:
     - dask==0.19.4
-prefix: /srv/jenkins/workspace/Sandbox/delivery_merge/miniconda3/envs/hstdp-2019.3-linux-py36.02

--- a/hstdp/2019.3/dev/hstdp-2019.3-linux-py36.03.yml
+++ b/hstdp/2019.3/dev/hstdp-2019.3-linux-py36.03.yml
@@ -1,4 +1,3 @@
-name: hstdp-2019.3-linux-py36.03
 channels:
   - http://ssb.stsci.edu/astroconda
   - defaults
@@ -150,4 +149,3 @@ dependencies:
   - stwcs=1.5.1rc3.dev0+ga6e6a99=py36_2
   - pip:
     - dask==1.2.2
-prefix: /srv/jenkins/workspace/Sandbox/delivery_merge/miniconda/envs/hstdp-2019.3-linux-py36.03

--- a/hstdp/2019.3/dev/hstdp-2019.3-osx-py36.00.yml
+++ b/hstdp/2019.3/dev/hstdp-2019.3-osx-py36.00.yml
@@ -1,4 +1,3 @@
-name: hstdp-2019.3-osx-py36.00
 channels:
   - http://ssb.stsci.edu/astroconda
   - defaults
@@ -150,4 +149,3 @@ dependencies:
   - tweakwcs=0.5.0=py36_0
   - pip:
     - dask==0.19.4
-prefix: /Users/iraf/build/pembry/workspace/Sandbox/delivery_merge/miniconda3/envs/hstdp-2019.3-osx-py36.00

--- a/hstdp/2019.3/dev/hstdp-2019.3-osx-py36.01.yml
+++ b/hstdp/2019.3/dev/hstdp-2019.3-osx-py36.01.yml
@@ -1,4 +1,3 @@
-name: hstdp-2019.3-osx-py36.01
 channels:
   - http://ssb.stsci.edu/astroconda
   - defaults
@@ -150,4 +149,3 @@ dependencies:
   - tweakwcs=0.5.0=py36_0
   - pip:
     - dask==0.19.4
-prefix: /Users/iraf/build/pembry/workspace/Sandbox/delivery_merge/miniconda3/envs/hstdp-2019.3-osx-py36.01

--- a/hstdp/2019.3/dev/hstdp-2019.3-osx-py36.02.yml
+++ b/hstdp/2019.3/dev/hstdp-2019.3-osx-py36.02.yml
@@ -1,4 +1,3 @@
-name: hstdp-2019.3-osx-py36.02
 channels:
   - http://ssb.stsci.edu/astroconda
   - defaults
@@ -150,4 +149,3 @@ dependencies:
   - photutils=0.6.dev121+gcc9bb453=py36_0
   - pip:
     - dask==0.19.4
-prefix: /Users/iraf/build/pembry/workspace/Sandbox/delivery_merge/miniconda3/envs/hstdp-2019.3-osx-py36.02

--- a/hstdp/2019.3/dev/hstdp-2019.3-osx-py36.03.yml
+++ b/hstdp/2019.3/dev/hstdp-2019.3-osx-py36.03.yml
@@ -1,4 +1,3 @@
-name: hstdp-2019.3-osx-py36.03
 channels:
   - http://ssb.stsci.edu/astroconda
   - defaults
@@ -149,4 +148,3 @@ dependencies:
   - stwcs=1.5.1rc3.dev0+ga6e6a99=py36_2
   - pip:
     - dask==1.2.2
-prefix: /Users/iraf/build/pembry/workspace/Sandbox/delivery_merge/miniconda/envs/hstdp-2019.3-osx-py36.03

--- a/hstdp/2019.3/hstdp-2019.3-linux-py36.final.yml
+++ b/hstdp/2019.3/hstdp-2019.3-linux-py36.final.yml
@@ -1,4 +1,3 @@
-name: drizfinaltest
 channels:
   - http://ssb.stsci.edu/astroconda
   - defaults
@@ -146,5 +145,4 @@ dependencies:
   - yaml=0.1.7=had09818_2
   - zlib=1.2.11=h7b6447c_3
   - zstd=1.3.7=h0b5b093_0
-prefix: /home/iraf/miniconda/envs/drizfinaltest
 

--- a/hstdp/2019.3/hstdp-2019.3-osx-py36.final.txt
+++ b/hstdp/2019.3/hstdp-2019.3-osx-py36.final.txt
@@ -143,4 +143,4 @@ http://ssb.stsci.edu/astroconda/osx-64/wfc3tools-1.3.5-py36_0.tar.bz2
 http://ssb.stsci.edu/astroconda/osx-64/wfpc2tools-1.0.4-py36_0.tar.bz2
 http://ssb.stsci.edu/astroconda/osx-64/costools-1.2.3-py36_0.tar.bz2
 http://ssb.stsci.edu/astroconda/osx-64/stsci.skypac-1.0.4-py36_0.tar.bz2
-file:///Users/mrendina/miniconda3/conda-bld/osx-64/drizzlepac-3.0.2-py36h7b7c402_0.tar.bz2
+http://ssb.stsci.edu/astroconda/osx-64/drizzlepac-3.0.2-py36h7b7c402_0.tar.bz2

--- a/hstdp/2019.3/hstdp-2019.3-osx-py36.final.yml
+++ b/hstdp/2019.3/hstdp-2019.3-osx-py36.final.yml
@@ -1,4 +1,3 @@
-name: drizfinaltest
 channels:
   - http://ssb.stsci.edu/astroconda
   - defaults
@@ -145,5 +144,4 @@ dependencies:
   - yaml=0.1.7=hc338f04_2
   - zlib=1.2.11=h1de35cc_3
   - zstd=1.3.7=h5bba6e5_0
-prefix: /Users/mrendina/miniconda3/envs/drizfinaltest
 

--- a/hstdp/2019.3b/dev/hstdp-2019.3b-osx-py36.00.txt
+++ b/hstdp/2019.3b/dev/hstdp-2019.3b-osx-py36.00.txt
@@ -143,4 +143,4 @@ http://ssb.stsci.edu/astroconda/osx-64/wfc3tools-1.3.5-py36_0.tar.bz2
 http://ssb.stsci.edu/astroconda/osx-64/wfpc2tools-1.0.4-py36_0.tar.bz2
 http://ssb.stsci.edu/astroconda/osx-64/costools-1.2.3-py36_0.tar.bz2
 http://ssb.stsci.edu/astroconda/osx-64/stsci.skypac-1.0.4-py36_0.tar.bz2
-file:///Users/mrendina/miniconda3/conda-bld/osx-64/drizzlepac-3.0.2-py36h7b7c402_0.tar.bz2
+http://ssb.stsci.edu/astroconda/osx-64/drizzlepac-3.0.2-py36h7b7c402_0.tar.bz2

--- a/hstdp/2019.3b/hstdp-2019.3b-linux-py36.final.yml
+++ b/hstdp/2019.3b/hstdp-2019.3b-linux-py36.final.yml
@@ -1,7 +1,6 @@
 channels:
   - http://ssb.stsci.edu/astroconda
   - defaults
-  - http://ssb.stsci.edu/astroconda-j-pub-staging
 dependencies:
   - acstools=3.0.0=py36_0
   - asdf=2.3.3=py36_0

--- a/hstdp/2019.3b/hstdp-2019.3b-osx-py36.final.yml
+++ b/hstdp/2019.3b/hstdp-2019.3b-osx-py36.final.yml
@@ -1,7 +1,6 @@
 channels:
   - http://ssb.stsci.edu/astroconda
   - defaults
-  - http://ssb.stsci.edu/astroconda-j-pub-staging
 dependencies:
   - acstools=3.0.0=py36_0
   - asdf=2.3.3=py36_0


### PR DESCRIPTION
* Drizzlepac appeared in some legacy spec files with a local path due to an oversight during creation, those paths are changed to public URLs
* The staging channel need not appear in the final delivery iterations.
* Conda environment dump YAML files standardized to remove `name:` and `prefix:` fields for better generality.