### PR TITLE
Correct prefix list availability

### DIFF
--- a/jwstdp/utils/jwst_delivery_prep
+++ b/jwstdp/utils/jwst_delivery_prep
@@ -29,7 +29,7 @@ def modify_dep(line, text):
     return(line)
 
 
-def get_artifact_names(url):
+def get_artifact_names(url, prefixes):
     '''Retrieve list of all available artifacts in the target artifactory
     repository.'''
     names = []
@@ -38,7 +38,7 @@ def get_artifact_names(url):
     payload = result.readlines()
     for line in payload:
         line = str(line.decode())
-        for prefix in artifact_prefixes:
+        for prefix in prefixes:
             if prefix in line:
                 mat = re.search('(?<=").*(?=\")', line)
                 names.append(mat.group(0))
@@ -161,7 +161,9 @@ def main():
     config_map = []
     from collections import namedtuple
     confset = namedtuple('confset', ['config', 'os'])
-    artifacts = get_artifact_names(f'{art_url_base}/{art_repo}')
+    artifacts = get_artifact_names(
+            f'{art_url_base}/{art_repo}',
+            artifact_prefixes)
  
     # Download only the available artifacts that correspond to the
     # requested build name into new release dir. 


### PR DESCRIPTION
`artifact_prefixes` list was not available in the context where it was accessed. This passes it in.