### PR TITLE
Bump version of cfitsio

### DIFF
--- a/caldp/20200302/dev/caldp_cos1_20200302_linux_py36_rc1.yml
+++ b/caldp/20200302/dev/caldp_cos1_20200302_linux_py36_rc1.yml
@@ -6,9 +6,9 @@ dependencies:
 - bzip2=1.0.8=h7b6447c_0
 - ca-certificates=2020.1.1=0
 - certifi=2019.11.28=py36_0
-- cfitsio=3.470=hb7c8383_2
-- fitsverify=4.18=7
-- hstcal=2.3.1=0
+- cfitsio=3.470=0
+- fitsverify=4.18=9
+- hstcal=2.3.1=5
 - krb5=1.17.1=h173b8e3_0
 - ld_impl_linux-64=2.33.1=h53a641e_7
 - libcurl=7.68.0=h20c2e04_0

--- a/caldp/20200302/dev/caldp_cos1_20200302_osx_py36_rc1.yml
+++ b/caldp/20200302/dev/caldp_cos1_20200302_osx_py36_rc1.yml
@@ -5,9 +5,9 @@ dependencies:
 - bzip2=1.0.8=h1de35cc_0
 - ca-certificates=2020.1.1=0
 - certifi=2019.11.28=py36_0
-- cfitsio=3.470=hb33e7b4_2
-- fitsverify=4.18=7
-- hstcal=2.3.1=0
+- cfitsio=3.470=0
+- fitsverify=4.18=9
+- hstcal=2.3.1=5
 - krb5=1.17.1=hddcf347_0
 - libcurl=7.68.0=h051b688_0
 - libcxx=4.0.1=hcfea43d_1


### PR DESCRIPTION
to one provided by Astroconda.
Also rebuild hstcal and fitsverify to link against this version to prevent runtime errors encountered when running the originally delivered build of hstcal against conda's cfitsio.