### PR TITLE
Add missing Macos delivery set for latest iteration.

### DIFF
--- a/caldp/errorcalc/dev/CALDP_errorcalc_CAL_macos_py36_rc2.yml
+++ b/caldp/errorcalc/dev/CALDP_errorcalc_CAL_macos_py36_rc2.yml
@@ -1,0 +1,100 @@
+# delivery_name: CALDP_errorcalc_CAL_rc2
+# creation_time: Fri Sep 25 12:19:00 2020
+# conda_version: 4.8.5
+# condabuild_version: 4.8.5
+channels:
+- defaults
+- https://ssb.stsci.edu/astroconda
+- https://ssb.stsci.edu/astroconda-staging
+dependencies:
+- bzip2=1.0.8=h1de35cc_0
+- ca-certificates=2020.7.22=0
+- certifi=2020.6.20=py36_0
+- cfitsio=3.470=1
+- fitsverify=4.18=13
+- hstcal=2.5.0rc1.dev0+ge08676b0=0
+- libcxx=10.0.0=1
+- libedit=3.1.20191231=h1de35cc_1
+- libffi=3.3=hb1e8313_2
+- libgcc=4.8.5=hdbeacc1_10
+- libgfortran=3.0.1=h93005f0_2
+- ncurses=6.2=h0a44026_1
+- openssl=1.1.1h=haf1e3a3_0
+- pip=20.2.2=py36_0
+- python=3.6.12=h26836e1_2
+- readline=8.0=h1de35cc_0
+- setuptools=49.6.0=py36_0
+- sqlite=3.33.0=hffcf06c_0
+- tk=8.6.10=hb0a8c7a_0
+- wheel=0.35.1=py_0
+- xz=5.2.5=h1de35cc_0
+- zlib=1.2.11=h1de35cc_3
+- pip:
+  - acstools==3.2.0
+  - astropy==4.0.1.post1
+  - astroquery==0.4.1
+  - beautifulsoup4==4.9.1
+  - bokeh==2.2.1
+  - git+https://github.com/spacetelescope/calcos@3.3.10-rc1
+  - chardet==3.0.4
+  - costools==1.2.3
+  - crds==7.6.0
+  - cycler==0.10.0
+  - decorator==4.4.2
+  - drizzlepac==3.1.8
+  - filelock==3.0.12
+  - fitsblender==0.3.6
+  - html5lib==1.1
+  - idna==2.10
+  - imageio==2.9.0
+  - importlib-metadata==1.7.0
+  - jinja2==2.11.2
+  - joblib==0.16.0
+  - keyring==21.4.0
+  - kiwisolver==1.2.0
+  - lxml==4.5.2
+  - markupsafe==1.1.1
+  - matplotlib==3.3.2
+  - networkx==2.5
+  - nictools==1.1.5
+  - nose==1.3.7
+  - numexpr==2.7.1
+  - numpy==1.19.2
+  - packaging==20.4
+  - pandas==1.1.2
+  - parsley==1.3
+  - photutils==0.7.2
+  - pillow==7.2.0
+  - pyparsing==2.4.7
+  - pypdf2==1.26.0
+  - pysynphot==1.0.0
+  - python-dateutil==2.8.1
+  - pytz==2020.1
+  - pywavelets==1.1.1
+  - pyyaml==5.3.1
+  - requests==2.24.0
+  - scikit-image==0.17.2
+  - scikit-learn==0.23.2
+  - scipy==1.5.2
+  - six==1.15.0
+  - soupsieve==2.0.1
+  - spherical-geometry==1.2.18
+  - stistools==1.4.1
+  - stregion==1.1.6
+  - stsci-image==2.3.3
+  - stsci-imagestats==1.6.2
+  - stsci-skypac==1.0.5
+  - stsci-stimage==0.2.4
+  - stsci-tools==3.6.0
+  - stwcs==1.6.0
+  - tables==3.6.1
+  - threadpoolctl==2.1.0
+  - tifffile==2020.9.3
+  - tornado==6.0.4
+  - tweakwcs==0.6.5
+  - typing-extensions==3.7.4.3
+  - urllib3==1.25.10
+  - webencodings==0.5.1
+  - wfc3tools==1.3.5
+  - wfpc2tools==1.0.5
+  - zipp==3.1.0

--- a/caldp/errorcalc/latest-macos.yml
+++ b/caldp/errorcalc/latest-macos.yml
@@ -1,1 +1,1 @@
-dev/CALDP_errorcalc_COS_macos_py36_rc1.yml
+dev/CALDP_errorcalc_CAL_macos_py36_rc2.yml


### PR DESCRIPTION
`conda-build 3.20.0` fails when trying to access broken symlinks on Macos.
Reverted delivery build system to use `conda-build 3.18.11` in order to let Macos build complete.
Versions earlier than `3.18` also fail to build the necessary packages because of dependency resolution problems.