### PR TITLE
Correct condabuild_version values.

### DIFF
--- a/caldp/errorcalc/dev/CALDP_errorcalc_CAL_linux_py36_rc2.yml
+++ b/caldp/errorcalc/dev/CALDP_errorcalc_CAL_linux_py36_rc2.yml
@@ -1,7 +1,7 @@
 # delivery_name: CALDP_errorcalc_CAL_rc2
 # creation_time: Mon Sep 21 12:38:07 2020
 # conda_version: 4.8.2
-# condabuild_version: 4.8.2
+# condabuild_version: 3.20.2
 channels:
 - defaults
 - https://ssb.stsci.edu/astroconda

--- a/caldp/errorcalc/dev/CALDP_errorcalc_CAL_macos_py36_rc2.yml
+++ b/caldp/errorcalc/dev/CALDP_errorcalc_CAL_macos_py36_rc2.yml
@@ -1,7 +1,7 @@
 # delivery_name: CALDP_errorcalc_CAL_rc2
 # creation_time: Fri Sep 25 12:19:00 2020
 # conda_version: 4.8.5
-# condabuild_version: 4.8.5
+# condabuild_version: 3.18.11
 channels:
 - defaults
 - https://ssb.stsci.edu/astroconda

--- a/caldp/errorcalc/dev/CALDP_errorcalc_COS_linux_py36_rc1.yml
+++ b/caldp/errorcalc/dev/CALDP_errorcalc_COS_linux_py36_rc1.yml
@@ -1,7 +1,7 @@
 # delivery_name: CALDP_errorcalc_COS_rc1
 # creation_time: Wed Sep 16 14:27:47 2020
 # conda_version: 4.8.2
-# condabuild_version: 4.8.2
+# condabuild_version: 3.18.11
 channels:
 - defaults
 - https://ssb.stsci.edu/astroconda

--- a/caldp/errorcalc/dev/CALDP_errorcalc_COS_macos_py36_rc1.yml
+++ b/caldp/errorcalc/dev/CALDP_errorcalc_COS_macos_py36_rc1.yml
@@ -1,7 +1,7 @@
 # delivery_name: CALDP_errorcalc_COS_rc1
 # creation_time: Wed Sep 16 14:28:27 2020
 # conda_version: 4.8.4
-# condabuild_version: 4.8.4
+# condabuild_version: 3.18.11
 channels:
 - defaults
 - https://ssb.stsci.edu/astroconda


### PR DESCRIPTION
A bug in the environment curation tool caused the field to reflect the version of conda instead of conda-build.