### PR TITLE
Update stwcs172

### DIFF
--- a/caldp/20211129/CALDP_20211129_CAL_linux_py38_final.yml
+++ b/caldp/20211129/CALDP_20211129_CAL_linux_py38_final.yml
@@ -1,5 +1,5 @@
 # delivery_name: CALDP_20211129_CAL_final
-# creation_time: Mon Nov 29 16:14:18 2021
+# creation_time: Tue Nov 30 15:18:13 2021
 # conda_version: 4.10.3
 # condabuild_version: 3.18.11
 channels:
@@ -10,8 +10,8 @@ dependencies:
 - _libgcc_mutex=0.1=main
 - _openmp_mutex=4.5=1_gnu
 - bzip2=1.0.8=h7b6447c_0
-- ca-certificates=2021.10.26=h06a4308_2
-- certifi=2021.10.8=py38h06a4308_0
+- ca-certificates=2021.7.5=h06a4308_1
+- certifi=2021.5.30=py38h06a4308_0
 - cfitsio=3.470=1
 - fitsverify=4.18=13
 - hstcal=2.7.2.dev0+gd395b8b8=0
@@ -23,10 +23,10 @@ dependencies:
 - libgfortran4=7.5.0=ha8ba4b0_17
 - libgomp=9.3.0=h5101ec6_17
 - libstdcxx-ng=9.3.0=hd4cf53a_17
-- ncurses=6.3=h7f8727e_2
+- ncurses=6.2=he6710b0_1
 - openssl=1.1.1l=h7f8727e_0
-- pip=21.2.4=py38h06a4308_0
-- python=3.8.12=h12debd9_0
+- pip=21.0.1=py38h06a4308_0
+- python=3.8.11=h12debd9_0_cpython
 - readline=8.1=h27cfd23_0
 - setuptools=58.0.4=py38h06a4308_0
 - sqlite=3.36.0=hc218d9a_0
@@ -37,65 +37,63 @@ dependencies:
 - pip:
   - acstools==3.3.1
   - asdf==2.8.1
-  - astropy==5.0
-  - astroquery==0.4.4
+  - astropy==4.3.1
+  - astroquery==0.4.3
   - attrs==21.2.0
   - beautifulsoup4==4.10.0
-  - bokeh==2.4.2
+  - bokeh==2.4.0
   - calcos==3.3.11
-  - cffi==1.15.0
-  - charset-normalizer==2.0.8
+  - cffi==1.14.6
+  - charset-normalizer==2.0.6
   - costools==1.2.4
-  - crds==11.5.0
-  - cryptography==36.0.0
-  - cycler==0.11.0
+  - crds==11.4.3
+  - cryptography==35.0.0
+  - cycler==0.10.0
   - drizzlepac==3.3.1
-  - filelock==3.4.0
+  - filelock==3.3.0
   - fitsblender==0.3.6
-  - fonttools==4.28.2
   - html5lib==1.1
-  - idna==3.3
-  - imageio==2.13.0
-  - importlib-metadata==4.8.2
-  - importlib-resources==5.4.0
+  - idna==3.2
+  - imageio==2.9.0
+  - importlib-metadata==4.8.1
+  - importlib-resources==5.2.2
   - jeepney==0.7.1
-  - jinja2==3.0.3
+  - jinja2==3.0.2
   - jmespath==0.10.0
-  - joblib==1.1.0
+  - joblib==1.0.1
   - jsonschema==3.2.0
-  - keyring==23.4.0
+  - keyring==23.2.1
   - kiwisolver==1.3.2
-  - lxml==4.6.4
+  - lxml==4.6.3
   - markupsafe==2.0.1
-  - matplotlib==3.5.0
+  - matplotlib==3.4.3
   - mimeparse==0.1.3
   - networkx==2.6.3
   - nictools==1.1.5
-  - numpy==1.21.4
-  - packaging==21.3
-  - pandas==1.3.4
+  - numpy==1.21.2
+  - packaging==21.0
+  - pandas==1.3.3
   - parsley==1.3
   - photutils==1.1.0
-  - pillow==8.4.0
-  - pycparser==2.21
-  - pyerfa==2.0.0.1
-  - pyparsing==3.0.6
+  - pillow==8.3.2
+  - pycparser==2.20
+  - pyerfa==2.0.0
+  - pyparsing==2.4.7
   - pypdf2==1.26.0
   - pyrsistent==0.18.0
   - python-dateutil==2.8.2
   - pytz==2021.3
   - pyvo==1.1
-  - pywavelets==1.2.0
-  - pyyaml==6.0
+  - pywavelets==1.1.1
+  - pyyaml==5.4.1
   - requests==2.26.0
   - scikit-image==0.18.3
-  - scikit-learn==1.0.1
-  - scipy==1.7.3
+  - scikit-learn==1.0
+  - scipy==1.7.1
   - secretstorage==3.3.1
   - semantic-version==2.8.5
-  - setuptools-scm==6.3.2
   - six==1.16.0
-  - soupsieve==2.3.1
+  - soupsieve==2.2.1
   - spherical-geometry==1.2.20
   - stistools==1.4.1
   - stregion==1.1.6
@@ -106,11 +104,10 @@ dependencies:
   - stsci-tools==4.0.1
   - stwcs==1.7.2
   - threadpoolctl==3.0.0
-  - tifffile==2021.11.2
-  - tomli==1.2.2
+  - tifffile==2021.8.30
   - tornado==6.1
   - tweakwcs==0.7.3
-  - typing-extensions==4.0.0
+  - typing-extensions==3.10.0.2
   - urllib3==1.26.7
   - webencodings==0.5.1
   - wfc3tools==1.3.5

--- a/caldp/20211129/CALDP_20211129_CAL_macos_py38_final.yml
+++ b/caldp/20211129/CALDP_20211129_CAL_macos_py38_final.yml
@@ -1,5 +1,5 @@
 # delivery_name: CALDP_20211129_CAL_final
-# creation_time: Mon Nov 29 16:15:37 2021
+# creation_time: Tue Nov 30 15:19:12 2021
 # conda_version: 4.10.3
 # condabuild_version: 3.18.11
 channels:
@@ -8,8 +8,8 @@ channels:
 - https://ssb.stsci.edu/astroconda-staging
 dependencies:
 - bzip2=1.0.8=h1de35cc_0
-- ca-certificates=2021.10.26=hecd8cb5_2
-- certifi=2021.10.8=py38hecd8cb5_0
+- ca-certificates=2021.7.5=hecd8cb5_1
+- certifi=2021.5.30=py38hecd8cb5_0
 - cfitsio=3.470=1
 - fitsverify=4.18=13
 - hstcal=2.7.2.dev0+gd395b8b8=0
@@ -17,10 +17,10 @@ dependencies:
 - libffi=3.3=hb1e8313_2
 - libgcc=4.8.5=hdbeacc1_10
 - libgfortran=3.0.1=h93005f0_2
-- ncurses=6.3=hca72f7f_2
+- ncurses=6.2=h0a44026_1
 - openssl=1.1.1l=h9ed2024_0
-- pip=21.2.4=py38hecd8cb5_0
-- python=3.8.12=h88f2d9e_0
+- pip=21.0.1=py38hecd8cb5_0
+- python=3.8.11=h88f2d9e_1
 - readline=8.1=h9ed2024_0
 - setuptools=58.0.4=py38hecd8cb5_0
 - sqlite=3.36.0=hce871da_0
@@ -31,60 +31,58 @@ dependencies:
 - pip:
   - acstools==3.3.1
   - asdf==2.8.1
-  - astropy==5.0
-  - astroquery==0.4.4
+  - astropy==4.3.1
+  - astroquery==0.4.3
   - attrs==21.2.0
   - beautifulsoup4==4.10.0
-  - bokeh==2.4.2
+  - bokeh==2.4.0
   - calcos==3.3.11
-  - charset-normalizer==2.0.8
+  - charset-normalizer==2.0.6
   - costools==1.2.4
-  - crds==11.5.0
-  - cycler==0.11.0
+  - crds==11.4.3
+  - cycler==0.10.0
   - drizzlepac==3.3.1
-  - filelock==3.4.0
+  - filelock==3.3.0
   - fitsblender==0.3.6
-  - fonttools==4.28.2
   - html5lib==1.1
-  - idna==3.3
-  - imageio==2.13.0
-  - importlib-metadata==4.8.2
-  - importlib-resources==5.4.0
-  - jinja2==3.0.3
+  - idna==3.2
+  - imageio==2.9.0
+  - importlib-metadata==4.8.1
+  - importlib-resources==5.2.2
+  - jinja2==3.0.2
   - jmespath==0.10.0
-  - joblib==1.1.0
+  - joblib==1.0.1
   - jsonschema==3.2.0
-  - keyring==23.4.0
+  - keyring==23.2.1
   - kiwisolver==1.3.2
-  - lxml==4.6.4
+  - lxml==4.6.3
   - markupsafe==2.0.1
-  - matplotlib==3.5.0
+  - matplotlib==3.4.3
   - mimeparse==0.1.3
   - networkx==2.6.3
   - nictools==1.1.5
-  - numpy==1.21.4
-  - packaging==21.3
-  - pandas==1.3.4
+  - numpy==1.21.2
+  - packaging==21.0
+  - pandas==1.3.3
   - parsley==1.3
   - photutils==1.1.0
-  - pillow==8.4.0
-  - pyerfa==2.0.0.1
-  - pyparsing==3.0.6
+  - pillow==8.3.2
+  - pyerfa==2.0.0
+  - pyparsing==2.4.7
   - pypdf2==1.26.0
   - pyrsistent==0.18.0
   - python-dateutil==2.8.2
   - pytz==2021.3
   - pyvo==1.1
-  - pywavelets==1.2.0
-  - pyyaml==6.0
+  - pywavelets==1.1.1
+  - pyyaml==5.4.1
   - requests==2.26.0
   - scikit-image==0.18.3
-  - scikit-learn==1.0.1
-  - scipy==1.7.3
+  - scikit-learn==1.0
+  - scipy==1.7.1
   - semantic-version==2.8.5
-  - setuptools-scm==6.3.2
   - six==1.16.0
-  - soupsieve==2.3.1
+  - soupsieve==2.2.1
   - spherical-geometry==1.2.20
   - stistools==1.4.1
   - stregion==1.1.6
@@ -95,11 +93,10 @@ dependencies:
   - stsci-tools==4.0.1
   - stwcs==1.7.2
   - threadpoolctl==3.0.0
-  - tifffile==2021.11.2
-  - tomli==1.2.2
+  - tifffile==2021.8.30
   - tornado==6.1
   - tweakwcs==0.7.3
-  - typing-extensions==4.0.0
+  - typing-extensions==3.10.0.2
   - urllib3==1.26.7
   - webencodings==0.5.1
   - wfc3tools==1.3.5

--- a/caldp/20211129/release_notes.md
+++ b/caldp/20211129/release_notes.md
@@ -4,4 +4,4 @@
 ## 2021/11/29 - CALDP_stwcsfix_CAL_rc1
 ### hstcal 2.7.2
 ### drizzlepac 3.3.1
-
+### stwcs 1.7.2


### PR DESCRIPTION
Create a new build based on the 20211119 build, with the only change being an upgrade to STWCS 1.7.2.  This avoids problems introduced by the astropy 5.0 interface changes, particularly with respect to how tables are interpreted. 