### PR TITLE
fix `stpipe` version to newest release

### DIFF
--- a/jwstdp/1.13.1/reqs_macos-stable-deps.txt
+++ b/jwstdp/1.13.1/reqs_macos-stable-deps.txt
@@ -86,7 +86,7 @@ sphinxcontrib-qthelp==1.0.6
 sphinxcontrib-serializinghtml==1.1.9
 stcal==1.5.2
 stdatamodels==1.9.0
-stpipe==0.5.2
+stpipe==0.5.1
 stsci.image==2.3.5
 stsci.imagestats==1.8.0
 stsci.stimage==0.2.6

--- a/jwstdp/1.13.1/reqs_stable-deps.txt
+++ b/jwstdp/1.13.1/reqs_stable-deps.txt
@@ -86,7 +86,7 @@ sphinxcontrib-qthelp==1.0.6
 sphinxcontrib-serializinghtml==1.1.9
 stcal==1.5.2
 stdatamodels==1.9.0
-stpipe==0.5.2
+stpipe==0.5.1
 stsci.image==2.3.5
 stsci.imagestats==1.8.0
 stsci.stimage==0.2.6


### PR DESCRIPTION
fixes `stpipe` version (was `0.5.2`, but latest release is `0.5.1`)