### PR TITLE
CALDP-infrastructure: Manually bump RC2 to RC3

### DIFF
--- a/caldp/infrastructure/dev/CALDP_infrastructure_CAL_linux_py311_rc3.yml
+++ b/caldp/infrastructure/dev/CALDP_infrastructure_CAL_linux_py311_rc3.yml
@@ -1,0 +1,170 @@
+# delivery_name: CALDP_infrastructure_CAL_rc3
+# creation_time: Mon Mar 25 09:58:15 2024
+# conda_version: 4.10.3
+# condabuild_version: 3.18.11
+channels:
+- conda-forge
+dependencies:
+- _libgcc_mutex=0.1=conda_forge
+- _openmp_mutex=4.5=2_gnu
+- bzip2=1.0.8=hd590300_5
+- c-ares=1.27.0=hd590300_0
+- ca-certificates=2024.2.2=hbcca054_0
+- cfitsio=4.3.1=hbdc6101_0
+- fitsverify=4.22=h6b5e9fc_0
+- hstcal=3.0.0=h6d95b9f_0
+- keyutils=1.6.1=h166bdaf_0
+- krb5=1.21.2=h659d440_0
+- ld_impl_linux-64=2.40=h41732ed_0
+- libcurl=8.6.0=hca28451_0
+- libedit=3.1.20191231=he28a2e2_2
+- libev=4.33=hd590300_2
+- libexpat=2.6.2=h59595ed_0
+- libffi=3.4.2=h7f98852_5
+- libgcc-ng=13.2.0=h807b86a_5
+- libgfortran-ng=13.2.0=h69a702a_5
+- libgfortran5=13.2.0=ha4646dd_5
+- libgomp=13.2.0=h807b86a_5
+- libnghttp2=1.58.0=h47da74e_1
+- libnsl=2.0.1=hd590300_0
+- libsqlite=3.45.2=h2797004_0
+- libssh2=1.11.0=h0841786_0
+- libstdcxx-ng=13.2.0=h7e041cc_5
+- libuuid=2.38.1=h0b41bf4_0
+- libxcrypt=4.4.36=hd590300_1
+- libzlib=1.2.13=hd590300_5
+- ncurses=6.4.20240210=h59595ed_0
+- openssl=3.2.1=hd590300_1
+- pip=24.0=pyhd8ed1ab_0
+- python=3.11.8=hab00c5b_0_cpython
+- readline=8.2=h8228510_1
+- setuptools=69.2.0=pyhd8ed1ab_0
+- tk=8.6.13=noxft_h4845f30_101
+- wheel=0.43.0=pyhd8ed1ab_0
+- xz=5.2.6=h166bdaf_0
+- zstd=1.5.5=hfc55251_0
+- pip:
+  - acstools==3.7.0
+  - alabaster==0.7.16
+  - asdf==3.0.1
+  - asdf-astropy==0.5.0
+  - asdf-coordinates-schemas==0.2.0
+  - asdf-standard==1.0.3
+  - asdf-transform-schemas==0.4.0
+  - asdf-unit-schemas==0.1.0
+  - asdf-wcs-schemas==0.3.0
+  - astrocut==0.9
+  - astropy==6.0.0
+  - astropy-iers-data==0.2024.2.19.0.28.47
+  - astroquery==0.4.6
+  - attrs==23.2.0
+  - babel==2.14.0
+  - beautifulsoup4==4.12.3
+  - blosc2==2.5.1
+  - bokeh==3.3.4
+  - calcos==3.4.8
+  - certifi==2024.2.2
+  - cffi==1.16.0
+  - charset-normalizer==3.3.2
+  - contourpy==1.2.0
+  - costools==1.2.6
+  - crds==11.17.19
+  - cryptography==42.0.4
+  - cycler==0.12.1
+  - cython==3.0.8
+  - datetime==5.4
+  - docutils==0.20.1
+  - git+https://github.com/spacetelescope/drizzlepac@3.7.0rc2
+  - et-xmlfile==1.1.0
+  - filelock==3.13.1
+  - fitsblender==0.4.3
+  - fonttools==4.49.0
+  - gwcs==0.20.0
+  - hasp==1.0
+  - html5lib==1.1
+  - idna==3.6
+  - imageio==2.34.0
+  - imagesize==1.4.1
+  - importlib-metadata==7.0.1
+  - jaraco-classes==3.3.1
+  - jaraco-context==4.3.0
+  - jaraco-functools==4.0.0
+  - jeepney==0.8.0
+  - jinja2==3.1.3
+  - jmespath==1.0.1
+  - joblib==1.3.2
+  - keyring==24.3.0
+  - kiwisolver==1.4.5
+  - lazy-loader==0.3
+  - lxml==5.1.0
+  - markupsafe==2.0.1
+  - matplotlib==3.8.3
+  - more-itertools==10.2.0
+  - msgpack==1.0.7
+  - ndindex==1.8
+  - networkx==3.2.1
+  - nictools==1.1.5
+  - numexpr==2.9.0
+  - numpy==1.26.4
+  - numpydoc==1.6.0
+  - openpyxl==3.1.2
+  - packaging==23.2
+  - pandas==2.2.0
+  - parsley==1.3
+  - photutils==1.11.0
+  - pillow==10.2.0
+  - plotly==5.19.0
+  - py-cpuinfo==9.0.0
+  - pycparser==2.21
+  - pyerfa==2.0.1.1
+  - pygments==2.17.2
+  - pyparsing==3.1.1
+  - pypdf2==3.0.1
+  - pysiaf==0.21.1
+  - python-dateutil==2.8.2
+  - pytz==2024.1
+  - pyvo==1.5
+  - pyyaml==6.0.1
+  - requests==2.31.0
+  - scikit-image==0.22.0
+  - scikit-learn==1.4.1.post1
+  - scipy==1.12.0
+  - secretstorage==3.3.3
+  - semantic-version==2.10.0
+  - six==1.16.0
+  - snowballstemmer==2.2.0
+  - soupsieve==2.5
+  - spherical-geometry==1.3.1
+  - sphinx==7.2.6
+  - sphinxcontrib-applehelp==1.0.8
+  - sphinxcontrib-devhelp==1.0.6
+  - sphinxcontrib-htmlhelp==2.0.5
+  - sphinxcontrib-jsmath==1.0.1
+  - sphinxcontrib-qthelp==1.0.7
+  - sphinxcontrib-serializinghtml==1.1.10
+  - stistools==1.4.4
+  - stregion==1.1.7
+  - stsci-image==2.3.5
+  - stsci-imagestats==1.8.1
+  - stsci-skypac==1.0.9
+  - stsci-stimage==0.2.6
+  - stsci-tools==4.1.0
+  - stwcs==1.7.2
+  - tables==3.9.2
+  - tabulate==0.9.0
+  - tenacity==8.2.3
+  - threadpoolctl==3.3.0
+  - tifffile==2024.2.12
+  - tornado==6.4
+  - tweakwcs==0.8.6
+  - typing-extensions==4.9.0
+  - tzdata==2024.1
+  - ullyses==4.1.0
+  - ullyses-utils==3.1.0
+  - urllib3==2.2.1
+  - webencodings==0.5.1
+  - wfc3tools==1.5.0
+  - wfpc2tools==1.0.5
+  - xyzservices==2023.10.1
+  - zipp==3.17.0
+  - zope-interface==6.2

--- a/caldp/infrastructure/dev/CALDP_infrastructure_CAL_macos_py311_rc3.yml
+++ b/caldp/infrastructure/dev/CALDP_infrastructure_CAL_macos_py311_rc3.yml
@@ -1,0 +1,157 @@
+# delivery_name: CALDP_infrastructure_CAL_rc3
+# creation_time: Mon Mar 25 09:49:44 2024
+# conda_version: 4.12.0
+# condabuild_version: 3.18.11
+channels:
+- conda-forge
+dependencies:
+- bzip2=1.0.8=h10d778d_5
+- c-ares=1.27.0=h10d778d_0
+- ca-certificates=2024.2.2=h8857fd0_0
+- cfitsio=4.3.1=h60fb419_0
+- fitsverify=4.22=hf2275c7_0
+- hstcal=3.0.0=h990e026_0
+- krb5=1.21.2=hb884880_0
+- libcurl=8.6.0=h726d00d_0
+- libcxx=16.0.6=hd57cbcb_0
+- libedit=3.1.20191231=h0678c8f_2
+- libev=4.33=h10d778d_2
+- libexpat=2.6.2=h73e2aa4_0
+- libffi=3.4.2=h0d85af4_5
+- libgfortran=5.0.0=13_2_0_h97931a8_3
+- libgfortran5=13.2.0=h2873a65_3
+- libnghttp2=1.58.0=h64cf6d3_1
+- libsqlite=3.45.2=h92b6c6a_0
+- libssh2=1.11.0=hd019ec5_0
+- libzlib=1.2.13=h8a1eda9_5
+- llvm-openmp=18.1.2=hb6ac08f_0
+- ncurses=6.4.20240210=h73e2aa4_0
+- openssl=3.2.1=hd75f5a5_1
+- pip=24.0=pyhd8ed1ab_0
+- python=3.11.8=h9f0c242_0_cpython
+- readline=8.2=h9e318b2_1
+- setuptools=69.2.0=pyhd8ed1ab_0
+- tk=8.6.13=h1abcd95_1
+- wheel=0.43.0=pyhd8ed1ab_0
+- xz=5.2.6=h775f41a_0
+- zstd=1.5.5=h829000d_0
+- pip:
+  - acstools==3.7.0
+  - alabaster==0.7.16
+  - asdf==3.0.1
+  - asdf-astropy==0.5.0
+  - asdf-coordinates-schemas==0.2.0
+  - asdf-standard==1.0.3
+  - asdf-transform-schemas==0.4.0
+  - asdf-unit-schemas==0.1.0
+  - asdf-wcs-schemas==0.3.0
+  - astrocut==0.9
+  - astropy==6.0.0
+  - astropy-iers-data==0.2024.2.19.0.28.47
+  - astroquery==0.4.6
+  - attrs==23.2.0
+  - babel==2.14.0
+  - beautifulsoup4==4.12.3
+  - blosc2==2.5.1
+  - bokeh==3.3.4
+  - calcos==3.4.8
+  - certifi==2024.2.2
+  - charset-normalizer==3.3.2
+  - contourpy==1.2.0
+  - costools==1.2.6
+  - crds==11.17.19
+  - cycler==0.12.1
+  - cython==3.0.8
+  - datetime==5.4
+  - docutils==0.20.1
+  - git+https://github.com/spacetelescope/drizzlepac@3.7.0rc2
+  - et-xmlfile==1.1.0
+  - filelock==3.13.1
+  - fitsblender==0.4.3
+  - fonttools==4.49.0
+  - gwcs==0.20.0
+  - hasp==1.0
+  - html5lib==1.1
+  - idna==3.6
+  - imageio==2.34.0
+  - imagesize==1.4.1
+  - importlib-metadata==7.0.1
+  - jaraco-classes==3.3.1
+  - jaraco-context==4.3.0
+  - jaraco-functools==4.0.0
+  - jinja2==3.1.3
+  - jmespath==1.0.1
+  - joblib==1.3.2
+  - keyring==24.3.0
+  - kiwisolver==1.4.5
+  - lazy-loader==0.3
+  - lxml==5.1.0
+  - markupsafe==2.0.1
+  - matplotlib==3.8.3
+  - more-itertools==10.2.0
+  - msgpack==1.0.7
+  - ndindex==1.8
+  - networkx==3.2.1
+  - nictools==1.1.5
+  - numexpr==2.9.0
+  - numpy==1.26.4
+  - numpydoc==1.6.0
+  - openpyxl==3.1.2
+  - packaging==23.2
+  - pandas==2.2.0
+  - parsley==1.3
+  - photutils==1.11.0
+  - pillow==10.2.0
+  - plotly==5.19.0
+  - py-cpuinfo==9.0.0
+  - pyerfa==2.0.1.1
+  - pygments==2.17.2
+  - pyparsing==3.1.1
+  - pypdf2==3.0.1
+  - pysiaf==0.21.1
+  - python-dateutil==2.8.2
+  - pytz==2024.1
+  - pyvo==1.5
+  - pyyaml==6.0.1
+  - requests==2.31.0
+  - scikit-image==0.22.0
+  - scikit-learn==1.4.1.post1
+  - scipy==1.12.0
+  - semantic-version==2.10.0
+  - six==1.16.0
+  - snowballstemmer==2.2.0
+  - soupsieve==2.5
+  - spherical-geometry==1.3.1
+  - sphinx==7.2.6
+  - sphinxcontrib-applehelp==1.0.8
+  - sphinxcontrib-devhelp==1.0.6
+  - sphinxcontrib-htmlhelp==2.0.5
+  - sphinxcontrib-jsmath==1.0.1
+  - sphinxcontrib-qthelp==1.0.7
+  - sphinxcontrib-serializinghtml==1.1.10
+  - stistools==1.4.4
+  - stregion==1.1.7
+  - stsci-image==2.3.5
+  - stsci-imagestats==1.8.1
+  - stsci-skypac==1.0.9
+  - stsci-stimage==0.2.6
+  - stsci-tools==4.1.0
+  - stwcs==1.7.2
+  - tables==3.9.2
+  - tabulate==0.9.0
+  - tenacity==8.2.3
+  - threadpoolctl==3.3.0
+  - tifffile==2024.2.12
+  - tornado==6.4
+  - tweakwcs==0.8.6
+  - typing-extensions==4.9.0
+  - tzdata==2024.1
+  - ullyses==4.1.0
+  - ullyses-utils==3.1.0
+  - urllib3==2.2.1
+  - webencodings==0.5.1
+  - wfc3tools==1.5.0
+  - wfpc2tools==1.0.5
+  - xyzservices==2023.10.1
+  - zipp==3.17.0
+  - zope-interface==6.2

--- a/caldp/infrastructure/latest-linux.yml
+++ b/caldp/infrastructure/latest-linux.yml
@@ -1,1 +1,1 @@
-dev/CALDP_infrastructure_CAL_linux_py311_rc2.yml
+dev/CALDP_infrastructure_CAL_linux_py311_rc3.yml

--- a/caldp/infrastructure/latest-macos.yml
+++ b/caldp/infrastructure/latest-macos.yml
@@ -1,1 +1,1 @@
-dev/CALDP_infrastructure_CAL_macos_py311_rc2.yml
+dev/CALDP_infrastructure_CAL_macos_py311_rc3.yml


### PR DESCRIPTION
* Circumvents a bug in calenv that prevents upgrading stsci.imagestats 1.8.0 to 1.8.1