### PR TITLE
[`jwstdp/1.14.0`] Python 3.12 -> Python 3.11

### DIFF
--- a/jwstdp/1.14.0/conda_python_stable-deps.txt
+++ b/jwstdp/1.14.0/conda_python_stable-deps.txt
@@ -12,7 +12,6 @@ https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.conda
 https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.conda
 https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-11.2.0-h1234567_1.conda
 https://repo.anaconda.com/pkgs/main/linux-64/bzip2-1.0.8-h5eee18b_5.conda
-https://repo.anaconda.com/pkgs/main/linux-64/expat-2.5.0-h6a678d5_0.conda
 https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.4-h6a678d5_0.conda
 https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.41.5-h5eee18b_0.conda
 https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.4-h6a678d5_0.conda
@@ -22,7 +21,7 @@ https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.13-h5eee18b_0.conda
 https://repo.anaconda.com/pkgs/main/linux-64/readline-8.2-h5eee18b_0.conda
 https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.12-h1ccaba5_0.conda
 https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.41.2-h5eee18b_0.conda
-https://repo.anaconda.com/pkgs/main/linux-64/python-3.12.2-h996f2a0_0.conda
-https://repo.anaconda.com/pkgs/main/linux-64/setuptools-68.2.2-py312h06a4308_0.conda
-https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.41.2-py312h06a4308_0.conda
-https://repo.anaconda.com/pkgs/main/linux-64/pip-23.3.1-py312h06a4308_0.conda
+https://repo.anaconda.com/pkgs/main/linux-64/python-3.11.8-h955ad1f_0.conda
+https://repo.anaconda.com/pkgs/main/linux-64/setuptools-68.2.2-py311h06a4308_0.conda
+https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.41.2-py311h06a4308_0.conda
+https://repo.anaconda.com/pkgs/main/linux-64/pip-23.3.1-py311h06a4308_0.conda

--- a/jwstdp/1.14.0/reqs_macos-stable-deps.txt
+++ b/jwstdp/1.14.0/reqs_macos-stable-deps.txt
@@ -36,6 +36,7 @@ jmespath==1.0.1
 jplephem==2.21
 jsonschema==4.21.1
 jsonschema-specifications==2023.12.1
+jwst @ git+https://github.com/spacetelescope/jwst.git@1.14.0
 kiwisolver==1.4.5
 lazy_loader==0.3
 lxml==5.1.1

--- a/jwstdp/1.14.0/reqs_stable-deps.txt
+++ b/jwstdp/1.14.0/reqs_stable-deps.txt
@@ -13,7 +13,7 @@ Babel==2.14.0
 BayesicFitting==3.2.1
 certifi==2024.2.2
 charset-normalizer==3.3.2
-ci-watson==0.6.2
+ci_watson==0.6.2
 colorama==0.4.6
 contourpy==1.2.0
 coverage==7.4.4

--- a/jwstdp/1.14.0/reqs_stable-deps.txt
+++ b/jwstdp/1.14.0/reqs_stable-deps.txt
@@ -36,6 +36,7 @@ jmespath==1.0.1
 jplephem==2.21
 jsonschema==4.21.1
 jsonschema-specifications==2023.12.1
+jwst @ git+https://github.com/spacetelescope/jwst.git@1.14.0
 kiwisolver==1.4.5
 lazy_loader==0.3
 lxml==5.1.1

--- a/jwstdp/1.14.0/reqs_stable-deps.txt
+++ b/jwstdp/1.14.0/reqs_stable-deps.txt
@@ -13,7 +13,7 @@ Babel==2.14.0
 BayesicFitting==3.2.1
 certifi==2024.2.2
 charset-normalizer==3.3.2
-ci_watson==0.6.2
+ci-watson==0.6.2
 colorama==0.4.6
 contourpy==1.2.0
 coverage==7.4.4


### PR DESCRIPTION
the frozen requirements generated by the `RT/JWST` regression tests use Python 3.12; the delivered environment needs to be Python 3.11

I followed this procedure to create these files:
```shell
cd jwstdp/1.14.0/
conda create -n jwstdp-1.14.0 python=3.11 -c defaults
conda activate jwstdp-1.14.0
conda list --explicit > conda_python_stable-deps.txt

pip install -r reqs_stable-deps.txt
pip freeze > reqs_stable-deps.txt
```

diff from previous build:
```diff
diff 1.13.3/README.md 1.14.0/README.md
17,18c17,18
< $ conda create -n jwstdp-1.13.3 --file
< https://ssb.stsci.edu/releases/jwstdp/1.13.3/conda_python_stable-deps.txt
---
> $ conda create -n jwstdp-1.14.0 --file
> https://ssb.stsci.edu/releases/jwstdp/1.14.0/conda_python_stable-deps.txt
23c23
< $ source activate jwstdp-1.13.3
---
> $ source activate jwstdp-1.14.0
28c28
< $ pip install -r https://ssb.stsci.edu/releases/jwstdp/1.13.3/reqs_stable-deps.txt
---
> $ pip install -r https://ssb.stsci.edu/releases/jwstdp/1.14.0/reqs_stable-deps.txt
37,38c37,38
< $ conda create -n jwstdp-1.13.3 --file
< https://ssb.stsci.edu/releases/jwstdp/1.13.3/conda_python_macos-stable-deps.txt
---
> $ conda create -n jwstdp-1.14.0 --file
> https://ssb.stsci.edu/releases/jwstdp/1.14.0/conda_python_macos-stable-deps.txt
43c43
< $ source activate jwstdp-1.13.3
---
> $ source activate jwstdp-1.14.0
48c48
< $ pip install -r https://ssb.stsci.edu/releases/jwstdp/1.13.3/reqs_macos-stable-deps.txt
---
> $ pip install -r https://ssb.stsci.edu/releases/jwstdp/1.14.0/reqs_macos-stable-deps.txt
diff 1.13.3/conda_python_macos-stable-deps.txt 1.14.0/conda_python_macos-stable-deps.txt
6,7c6,7
< https://repo.anaconda.com/pkgs/main/osx-64/bzip2-1.0.8-h1de35cc_0.conda
< https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2023.12.12-hecd8cb5_0.conda
---
> https://repo.anaconda.com/pkgs/main/osx-64/bzip2-1.0.8-h6c40b1e_5.conda
> https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2024.3.11-hecd8cb5_0.conda
10,11c10,11
< https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.conda
< https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.5-h6c40b1e_0.conda
---
> https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.conda
> https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.6-h6c40b1e_0.conda
13c13
< https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.12-hca72f7f_0.conda
---
> https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.13-hca72f7f_0.conda
17c17
< https://repo.anaconda.com/pkgs/main/osx-64/python-3.11.5-hf27a42d_0.conda
---
> https://repo.anaconda.com/pkgs/main/osx-64/python-3.11.8-hf27a42d_0.conda
diff 1.13.3/conda_python_stable-deps.txt 1.14.0/conda_python_stable-deps.txt
7c7
< https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2023.12.12-h06a4308_0.conda
---
> https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2024.3.11-h06a4308_0.conda
10c10
< https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.conda
---
> https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.conda
14c14
< https://repo.anaconda.com/pkgs/main/linux-64/bzip2-1.0.8-h7b6447c_0.conda
---
> https://repo.anaconda.com/pkgs/main/linux-64/bzip2-1.0.8-h5eee18b_5.conda
18,19c18,19
< https://repo.anaconda.com/pkgs/main/linux-64/openssl-3.0.12-h7f8727e_0.conda
< https://repo.anaconda.com/pkgs/main/linux-64/xz-5.4.5-h5eee18b_0.conda
---
> https://repo.anaconda.com/pkgs/main/linux-64/openssl-3.0.13-h7f8727e_0.conda
> https://repo.anaconda.com/pkgs/main/linux-64/xz-5.4.6-h5eee18b_0.conda
24c24
< https://repo.anaconda.com/pkgs/main/linux-64/python-3.11.5-h955ad1f_0.conda
---
> https://repo.anaconda.com/pkgs/main/linux-64/python-3.11.8-h955ad1f_0.conda
diff 1.13.3/reqs_macos-stable-deps.txt 1.14.0/reqs_macos-stable-deps.txt
1,10c1,10
< alabaster==0.7.13
< asdf==3.0.1
< asdf-astropy==0.5.0
< asdf-coordinates-schemas==0.2.0
< asdf-standard==1.0.3
< asdf-transform-schemas==0.4.0
< asdf-unit-schemas==0.1.0
< asdf-wcs-schemas==0.3.0
< astropy==6.0.0
< astropy-iers-data==0.2024.1.1.0.33.39
---
> alabaster==0.7.16
> asdf==3.1.0
> asdf-astropy==0.6.0
> asdf_coordinates_schemas==0.3.0
> asdf_standard==1.1.1
> asdf_transform_schemas==0.5.0
> asdf_unit_schemas==0.2.0
> asdf_wcs_schemas==0.4.0
> astropy==6.0.1
> astropy-iers-data==0.2024.3.25.0.29.50
13,14c13,14
< BayesicFitting==3.2.0
< certifi==2023.11.17
---
> BayesicFitting==3.2.1
> certifi==2024.2.2
19,20c19,20
< coverage==7.4.0
< crds==11.17.14
---
> coverage==7.4.4
> crds==11.17.19
23c23
< drizzle==1.14.4
---
> drizzle==1.15.1
25,28c25,28
< filelock==3.13.1
< fonttools==4.47.0
< future==0.18.3
< gwcs==0.20.0
---
> filelock==3.13.3
> fonttools==4.50.0
> future==1.0.0
> gwcs==0.21.0
30c30
< imageio==2.33.1
---
> imageio==2.34.0
32c32
< importlib-metadata==7.0.1
---
> importlib_metadata==7.1.0
34c34
< Jinja2==3.1.2
---
> Jinja2==3.1.3
37c37
< jsonschema==4.20.0
---
> jsonschema==4.21.1
39c39
< jwst @ git+https://github.com/spacetelescope/jwst.git@1.13.3
---
> jwst @ git+https://github.com/spacetelescope/jwst.git@1.14.0
42,44c42,44
< lxml==5.0.0
< MarkupSafe==2.1.3
< matplotlib==3.8.2
---
> lxml==5.1.1
> MarkupSafe==2.1.5
> matplotlib==3.8.3
46,47c46,47
< numpy==1.26.3
< numpydoc==1.6.0
---
> numpy==1.26.4
> numpydoc==1.7.0
50c50
< packaging==23.2
---
> packaging==24.0
52c52
< photutils==1.10.0
---
> photutils==1.11.0
54c54
< pluggy==1.3.0
---
> pluggy==1.4.0
56c56
< psutil==5.9.7
---
> psutil==5.9.8
59,64c59,64
< pyparsing==3.1.1
< pysiaf==0.21.0
< pytest==7.4.4
< pytest-cov==4.1.0
< pytest-doctestplus==1.1.0
< python-dateutil==2.8.2
---
> pyparsing==3.1.2
> pysiaf==0.22.0
> pytest==8.1.1
> pytest-cov==5.0.0
> pytest-doctestplus==1.2.1
> python-dateutil==2.9.0.post0
66,67c66,67
< readchar==4.0.5
< referencing==0.32.0
---
> readchar==4.0.6
> referencing==0.34.0
69,71c69,71
< requests-mock==1.11.0
< rpds-py==0.16.2
< ruff==0.1.11
---
> requests-mock==1.12.1
> rpds-py==0.18.0
> ruff==0.3.4
73c73
< scipy==1.11.4
---
> scipy==1.12.0
79,81c79,81
< sphinxcontrib-applehelp==1.0.7
< sphinxcontrib-devhelp==1.0.5
< sphinxcontrib-htmlhelp==2.0.4
---
> sphinxcontrib-applehelp==1.0.8
> sphinxcontrib-devhelp==1.0.6
> sphinxcontrib-htmlhelp==2.0.5
83,87c83,87
< sphinxcontrib-qthelp==1.0.6
< sphinxcontrib-serializinghtml==1.1.9
< stcal==1.5.2
< stdatamodels==1.9.0
< stpipe==0.5.1
---
> sphinxcontrib-qthelp==1.0.7
> sphinxcontrib-serializinghtml==1.1.10
> stcal==1.7.0
> stdatamodels==1.10.1
> stpipe==0.5.2
89c89
< stsci.imagestats==1.8.0
---
> stsci.imagestats==1.6.3
90a91
> synphot==1.3.post0
92,94c93,95
< tifffile==2023.12.9
< tweakwcs==0.8.5
< urllib3==2.1.0
---
> tifffile==2024.2.12
> tweakwcs==0.8.6
> urllib3==2.2.1
96c97
< zipp==3.17.0
---
> zipp==3.18.1
diff 1.13.3/reqs_stable-deps.txt 1.14.0/reqs_stable-deps.txt
1,10c1,10
< alabaster==0.7.13
< asdf==3.0.1
< asdf-astropy==0.5.0
< asdf-coordinates-schemas==0.2.0
< asdf-standard==1.0.3
< asdf-transform-schemas==0.4.0
< asdf-unit-schemas==0.1.0
< asdf-wcs-schemas==0.3.0
< astropy==6.0.0
< astropy-iers-data==0.2024.1.1.0.33.39
---
> alabaster==0.7.16
> asdf==3.1.0
> asdf-astropy==0.6.0
> asdf_coordinates_schemas==0.3.0
> asdf_standard==1.1.1
> asdf_transform_schemas==0.5.0
> asdf_unit_schemas==0.2.0
> asdf_wcs_schemas==0.4.0
> astropy==6.0.1
> astropy-iers-data==0.2024.3.25.0.29.50
13,14c13,14
< BayesicFitting==3.2.0
< certifi==2023.11.17
---
> BayesicFitting==3.2.1
> certifi==2024.2.2
19,20c19,20
< coverage==7.4.0
< crds==11.17.14
---
> coverage==7.4.4
> crds==11.17.19
23c23
< drizzle==1.14.4
---
> drizzle==1.15.1
25,28c25,28
< filelock==3.13.1
< fonttools==4.47.0
< future==0.18.3
< gwcs==0.20.0
---
> filelock==3.13.3
> fonttools==4.50.0
> future==1.0.0
> gwcs==0.21.0
30c30
< imageio==2.33.1
---
> imageio==2.34.0
32c32
< importlib-metadata==7.0.1
---
> importlib_metadata==7.1.0
34c34
< Jinja2==3.1.2
---
> Jinja2==3.1.3
37c37
< jsonschema==4.20.0
---
> jsonschema==4.21.1
39c39
< jwst @ git+https://github.com/spacetelescope/jwst.git@1.13.3
---
> jwst @ git+https://github.com/spacetelescope/jwst.git@1.14.0
42,44c42,44
< lxml==5.0.0
< MarkupSafe==2.1.3
< matplotlib==3.8.2
---
> lxml==5.1.1
> MarkupSafe==2.1.5
> matplotlib==3.8.3
46,47c46,47
< numpy==1.26.3
< numpydoc==1.6.0
---
> numpy==1.26.4
> numpydoc==1.7.0
50c50
< packaging==23.2
---
> packaging==24.0
52c52
< photutils==1.10.0
---
> photutils==1.11.0
54c54
< pluggy==1.3.0
---
> pluggy==1.4.0
56c56
< psutil==5.9.7
---
> psutil==5.9.8
59,64c59,64
< pyparsing==3.1.1
< pysiaf==0.21.0
< pytest==7.4.4
< pytest-cov==4.1.0
< pytest-doctestplus==1.1.0
< python-dateutil==2.8.2
---
> pyparsing==3.1.2
> pysiaf==0.22.0
> pytest==8.1.1
> pytest-cov==5.0.0
> pytest-doctestplus==1.2.1
> python-dateutil==2.9.0.post0
66,67c66,67
< readchar==4.0.5
< referencing==0.32.0
---
> readchar==4.0.6
> referencing==0.34.0
69,71c69,71
< requests-mock==1.11.0
< rpds-py==0.16.2
< ruff==0.1.11
---
> requests-mock==1.12.1
> rpds-py==0.18.0
> ruff==0.3.4
73c73
< scipy==1.11.4
---
> scipy==1.12.0
79,81c79,81
< sphinxcontrib-applehelp==1.0.7
< sphinxcontrib-devhelp==1.0.5
< sphinxcontrib-htmlhelp==2.0.4
---
> sphinxcontrib-applehelp==1.0.8
> sphinxcontrib-devhelp==1.0.6
> sphinxcontrib-htmlhelp==2.0.5
83,87c83,87
< sphinxcontrib-qthelp==1.0.6
< sphinxcontrib-serializinghtml==1.1.9
< stcal==1.5.2
< stdatamodels==1.9.0
< stpipe==0.5.1
---
> sphinxcontrib-qthelp==1.0.7
> sphinxcontrib-serializinghtml==1.1.10
> stcal==1.7.0
> stdatamodels==1.10.1
> stpipe==0.5.2
89c89
< stsci.imagestats==1.8.0
---
> stsci.imagestats==1.6.3
90a91
> synphot==1.3.post0
92,94c93,95
< tifffile==2023.12.9
< tweakwcs==0.8.5
< urllib3==2.1.0
---
> tifffile==2024.2.12
> tweakwcs==0.8.6
> urllib3==2.2.1
96c97
< zipp==3.17.0
---
> zipp==3.18.1
```